### PR TITLE
chore: use preRelease instead of deprecated prereleaseChannel

### DIFF
--- a/.autorel.yaml
+++ b/.autorel.yaml
@@ -11,7 +11,7 @@ commitTypes:
   - {type: ci, title: 🔧 Continuous Integration, release: patch}
 branches:
   - {name: main}
-  - {name: next, prereleaseChannel: next}
+  - {name: next, preRelease: next}
 publish: true
 preRun: |
   npm ci


### PR DESCRIPTION
## Summary

- Update `.autorel.yaml` to use `preRelease` instead of the deprecated `prereleaseChannel` option